### PR TITLE
Added include math.h to resolve compilation errors

### DIFF
--- a/README
+++ b/README
@@ -34,6 +34,7 @@ you have the compiler g++ >= 4.8
 	
 	cd ..
 
+	sudo ldconfig
 
 3) Compile CompositeSearch
 

--- a/src/compositesearch/compositeFamilies.cpp
+++ b/src/compositesearch/compositeFamilies.cpp
@@ -28,7 +28,7 @@
 #include <thread>
 #include <vector>
 #include <iomanip>
-
+#include <math.h>
 using namespace std;
 
 void compositeFamilies( map<unsigned int, list<unsigned long long int> >& familiesToCheck, map<unsigned long long int, geneInfo>& genes, map<unsigned long long int, familyInfo>& geneFamilies, unsigned int l, string timeInfo)

--- a/src/compositesearch/composites.cpp
+++ b/src/compositesearch/composites.cpp
@@ -28,7 +28,7 @@
 #include <thread>
 #include <vector>
 #include <iomanip>
-
+#include <math.h>
 using namespace std;
 
 void composites( map<unsigned int, list<unsigned long long int> >& refSubNodes, map<unsigned long long int, geneInfo >& genes, map<pair<unsigned long long int, unsigned long long int>, edgeValues>& edges, map<unsigned long long int, familyInfo >& geneFamilies, unsigned short int MAX_OVERLAP, unsigned short int minCov, unsigned int compositeFamMinSize, unsigned int componentFamMinSize, unsigned int l, string timeInfo)


### PR DESCRIPTION
I had problems compiling (error message below). I added include math.h to two files to resolve this.

After compiling, compositeSearch could not find the igraph libraries until I had ran sudo ldconfig to update links.

I have suggested adding this to the readme.

`g++ ./src/compositesearch/*.cpp -I/usr/local/include/igraph -L/usr/local/lib -ligraph -pthread -std=c++11 -o ./bin/compositeSearch
./src/compositesearch/compositeFamilies.cpp: In function ‘void compositeFamilies(std::map<unsigned int, std::__cxx11::list<long long unsigned int> >&, std::map<long long unsigned int, geneInfo>&, std::map<long long unsigned int, familyInfo>&, unsigned int, std::string)’:
./src/compositesearch/compositeFamilies.cpp:91:361: error: ‘round’ was not declared in this scope
   91 | entFamilies.size() << "\t" << singleNodeFamilies << "\t" <<  setprecision (2) << fixed << geneFamilies[familyID].getConnectivity() << "\t" << round((float)sumNbDomains/(float)NbComposites)  << "\t" << setprecision (2) << fixed << sumNoOverlap/(float)NbComposites << endl;
      |                                                                                                                                               ^~~~~

./src/compositesearch/composites.cpp: In function ‘void composites(std::map<unsigned int, std::__cxx11::list<long long unsigned int> >&, std::map<long long unsigned int, geneInfo>&, std::map<std::pair<long long unsigned int, long long unsigned int>, edgeValues>&, std::map<long long unsigned int, familyInfo>&, short unsigned int, short unsigned int, unsigned int, unsigned int, unsigned int, std::string)’:
./src/compositesearch/composites.cpp:274:38: error: ‘floor’ was not declared in this scope
  274 |        unsigned long long int mean = floor((float)diff/2.0);
      |                                      ^~~~~
make: *** [makefile:30: exec] Error 1`